### PR TITLE
Simplify Next/Tailwind migration — remove custom hacks and adopt Next.js conventions

### DIFF
--- a/components/atoms/Box.js
+++ b/components/atoms/Box.js
@@ -1,10 +1,14 @@
-import { styled } from "stitches.config";
 import { motion } from "framer-motion";
+import { stitchesToStyle } from "lib/style";
 
-const Box = styled(motion.div, {
-  // Reset
-  boxSizing: "border-box",
-  position: "relative",
-});
+const Box = ({ className = "", css, style, children, ...props }) => (
+  <motion.div
+    className={`box-border relative ${className}`.trim()}
+    style={{ ...stitchesToStyle(css), ...style }}
+    {...props}
+  >
+    {children}
+  </motion.div>
+);
 
 export default Box;

--- a/components/atoms/Button.js
+++ b/components/atoms/Button.js
@@ -1,85 +1,33 @@
-import { styled } from "stitches.config";
 import Text from "components/atoms/Text";
 import Icon from "components/atoms/Icon";
 import LinkTo from "components/utilities/LinkTo";
-const _Button = styled("button", {
-  // Reset
-  appearance: "none",
-  boxSizing: "border-box",
-  display: "inline-flex",
-  justifyContent: "center",
-  lineHeight: "1",
-  margin: "0",
-  outline: "none",
-  textDecoration: "none",
-  userSelect: "none",
-  WebkitTapHighlightColor: "rgba(0,0,0,0)",
-  "&::before": {
-    boxSizing: "border-box",
-  },
-  "&::after": {
-    boxSizing: "border-box",
-  },
-  border: "none",
-  verticalAlign: "middle",
 
-  // Local Tokens
-  $$primaryColor: "$colors$gray800",
-  $$contrastColor: "$colors$gray000",
+const Button = ({ children, iconName, href = false, variant, className = "", ...rest }) => {
+  const isGhost = variant === "ghost";
+  const buttonClasses = `appearance-none box-border inline-flex justify-center leading-none m-0 outline-none no-underline select-none border-0 align-middle rounded-full px-4 py-3 text-base transition-all duration-300 ease-out cursor-pointer ${
+    isGhost
+      ? "bg-transparent text-gray-100 hover:bg-gray-700"
+      : "bg-gray-800 text-gray-0 hover:bg-gray-700"
+  } ${className}`;
 
-  // Base Styles
-  borderRadius: "99999px",
-  backgroundColor: "$$primaryColor",
-  color: "$$contrastColor",
-  padding: "12px 16px",
-  fontSize: "16px",
-  transition: "$default",
-  cursor: "pointer",
-
-  "&:hover": {
-    $$primaryColor: "$colors$gray700",
-  },
-
-  variants: {
-    variant: {
-      ghost: {
-        backgroundColor: "transparent",
-        "&:hover": {
-          $$primaryColor: "$colors$gray700",
-          backgroundColor: "$$primaryColor",
-        },
-      },
-    },
-  },
-});
-
-const Button = (props) => {
-  const { children, iconName, href = false, ...rest } = props;
   const ButtonElement = () => (
-    <_Button {...rest}>
-      {iconName && (
-        <Icon
-          name={iconName}
-          css={{
-            width: "24px",
-            marginRight: "$space100",
-          }}
-        />
-      )}
-      <Text preset="body" css={{ paddingRight: iconName && "$space100" }}>
+    <button className={buttonClasses} {...rest}>
+      {iconName && <Icon name={iconName} className="w-6 mr-2" />}
+      <Text preset="body" className={iconName ? "pr-2" : ""}>
         {children}
       </Text>
-    </_Button>
+    </button>
   );
+
   if (href) {
     return (
       <LinkTo href={href}>
         <ButtonElement />
       </LinkTo>
     );
-  } else {
-    return <ButtonElement />;
   }
+
+  return <ButtonElement />;
 };
 
 export default Button;

--- a/components/atoms/Card.js
+++ b/components/atoms/Card.js
@@ -1,60 +1,20 @@
-import Box from "components/atoms/Box";
 import Flex from "components/atoms/Flex";
-import { styled } from "stitches.config";
 
-const _Card = styled(Flex, {
-  backgroundColor: "$gray900",
-  borderRadius: "$space$space100",
-  position: "relative",
-  overflow: "hidden",
-  clipPath: "border-box",
-  backfaceVisibility: "hidden",
-  transformStyle: "preserve-3d",
-  "& *": {
-    backfaceVisibility: "hidden",
-    transformStyle: "preserve-3d",
-  },
+const Card = ({ children, pressable = false, className = "", ...props }) => (
+  <Flex
+    className={`bg-gray-900 rounded-lg relative overflow-hidden [clip-path:border-box] [backface-visibility:hidden] [transform-style:preserve-3d] ${pressable ? "cursor-pointer" : ""} ${className}`.trim()}
+    whileHover={pressable ? { transform: "translateY(0px) scale(1.03)" } : undefined}
+    whileTap={pressable ? { transform: "translateY(0px) scale(0.97)" } : undefined}
+    {...props}
+  >
+    {children}
+  </Flex>
+);
 
-  variants: {
-    pressable: {
-      true: {
-        cursor: "pointer",
-      },
-    },
-  },
-});
-
-const Card = (props) => {
-  const { children, css, pressable = false } = props;
-  return (
-    <_Card
-      variants={{
-        default: { transform: "translateY(0px) scale(1)" },
-        hover: { transform: "translateY(0px) scale(1.03)" },
-        tap: { transform: "translateY(0px) scale(0.97)" },
-      }}
-      initial="default"
-      whileHover={pressable && "hover"}
-      whileTap={pressable && "tap"}
-      pressable={pressable}
-      css={css}
-      {...props}
-    >
-      {children}
-    </_Card>
-  );
-};
-
-Card.Content = styled(Flex, {
-  position: "relative",
-  padding: "$space400",
-  defaultVariants: {
-    direction: "column",
-  },
-
-  "@large": {
-    padding: "$space600",
-  },
-});
+Card.Content = ({ children, className = "", ...props }) => (
+  <Flex className={`relative p-6 lg:p-10 ${className}`.trim()} direction="column" {...props}>
+    {children}
+  </Flex>
+);
 
 export default Card;

--- a/components/atoms/Content.js
+++ b/components/atoms/Content.js
@@ -1,21 +1,16 @@
-import { styled, css } from "stitches.config";
 import Box from "./Box";
 
 export const contentWidth = "1128px";
 export const contentGutter = "16px";
 
-export const contentStyles = {
-  width: `calc(100% - ${contentGutter} - ${contentGutter})`,
-  maxWidth: `${contentWidth}`,
-  margin: "0 auto",
-
-  "@large": {
-    width: "calc(100% - 80px)",
-  },
-};
-
-export const Content = ({ children }) => {
-  return <Box css={{ ...contentStyles }}>{children}</Box>;
-};
+export const Content = ({ children, className = "", style, ...props }) => (
+  <Box
+    className={`mx-auto w-[calc(100%-32px)] lg:w-[calc(100%-80px)] ${className}`.trim()}
+    style={{ maxWidth: contentWidth, ...style }}
+    {...props}
+  >
+    {children}
+  </Box>
+);
 
 export default Content;

--- a/components/atoms/Flex.js
+++ b/components/atoms/Flex.js
@@ -1,106 +1,49 @@
-import { styled } from "stitches.config";
 import Box from "./Box";
 
-const Flex = styled(Box, {
-  display: "flex",
-  flexDirection: "column",
-  boxSizing: "border-box",
-  flex: 1,
-  position: "relative",
+const directionClasses = {
+  row: "flex-col md:flex-row",
+  column: "flex-col",
+  rowReverse: "flex-row-reverse",
+  columnReverse: "flex-col-reverse",
+};
 
-  $$gap: "$space$space300",
-  "@large": {
-    $$gap: "$space$space400",
-  },
+const alignClasses = {
+  start: "items-start",
+  center: "items-center",
+  end: "items-end",
+  stretch: "items-stretch",
+  baseline: "items-baseline",
+};
 
-  variants: {
-    direction: {
-      row: {
-        "@medium": {
-          flexDirection: "row",
-        },
-      },
-      column: {
-        flexDirection: "column",
-      },
-      rowReverse: {
-        flexDirection: "row-reverse",
-      },
-      columnReverse: {
-        flexDirection: "column-reverse",
-      },
-    },
-    align: {
-      start: {
-        alignItems: "flex-start",
-      },
-      center: {
-        alignItems: "center",
-      },
-      end: {
-        alignItems: "flex-end",
-      },
-      stretch: {
-        alignItems: "stretch",
-      },
-      baseline: {
-        alignItems: "baseline",
-      },
-    },
-    justify: {
-      start: {
-        justifyContent: "flex-start",
-      },
-      center: {
-        justifyContent: "center",
-      },
-      end: {
-        justifyContent: "flex-end",
-      },
-      between: {
-        justifyContent: "space-between",
-      },
-    },
-    wrap: {
-      noWrap: {
-        flexWrap: "nowrap",
-      },
-      wrap: {
-        flexWrap: "wrap",
-      },
-      wrapReverse: {
-        flexWrap: "wrap-reverse",
-      },
-    },
-    gap: {
-      true: {},
-    },
-  },
-  compoundVariants: [
-    {
-      gap: true,
-      direction: "row",
-      css: {
-        gapVertical: "$$gap",
-        "@medium": {
-          gapHorizontal: "$$gap",
-        },
-      },
-    },
-    {
-      gap: true,
-      direction: "column",
-      css: {
-        gapVertical: "$$gap",
-      },
-    },
-  ],
-  defaultVariants: {
-    direction: "row",
-    align: "stretch",
-    justify: "start",
-    wrap: "noWrap",
-  },
-});
+const justifyClasses = {
+  start: "justify-start",
+  center: "justify-center",
+  end: "justify-end",
+  between: "justify-between",
+};
+
+const wrapClasses = {
+  noWrap: "flex-nowrap",
+  wrap: "flex-wrap",
+  wrapReverse: "flex-wrap-reverse",
+};
+
+const Flex = ({
+  direction = "row",
+  align = "stretch",
+  justify = "start",
+  wrap = "noWrap",
+  gap = false,
+  className = "",
+  children,
+  ...props
+}) => (
+  <Box
+    className={`flex flex-1 box-border ${directionClasses[direction]} ${alignClasses[align]} ${justifyClasses[justify]} ${wrapClasses[wrap]} ${gap ? "gap-4 lg:gap-6" : ""} ${className}`.trim()}
+    {...props}
+  >
+    {children}
+  </Box>
+);
 
 export default Flex;

--- a/components/atoms/Grid.js
+++ b/components/atoms/Grid.js
@@ -1,47 +1,12 @@
-import { styled } from "stitches.config";
 import Box from "components/atoms/Box";
-import { contentStyles } from "components/atoms/Content";
-import Flex from "components/atoms/Flex";
 
-const Grid = styled(Box, {
-  padding: 0,
-  margin: 0,
-  width: "100%",
-  display: "grid",
-
-  variants: {
-    columns: {
-      1: {
-        gridTemplateColumns: "1fr",
-      },
-      2: {
-        gridTemplateColumns: "1fr",
-
-        "@medium": {
-          gridTemplateColumns: "1fr 1fr",
-        },
-      },
-    },
-    gapSize: {
-      default: {
-        gap: "$space300",
-        "@large": {
-          gap: "$space400",
-        },
-      },
-      large: {
-        gap: "$space500",
-        "@large": {
-          gap: "$space600",
-        },
-      },
-    },
-  },
-
-  defaultVariants: {
-    columns: 1,
-    gapSize: "default",
-  },
-});
+const Grid = ({ columns = 1, gapSize = "default", className = "", children, ...props }) => (
+  <Box
+    className={`grid w-full p-0 m-0 ${columns === 2 ? "grid-cols-1 md:grid-cols-2" : "grid-cols-1"} ${gapSize === "large" ? "gap-8 lg:gap-10" : "gap-4 lg:gap-6"} ${className}`.trim()}
+    {...props}
+  >
+    {children}
+  </Box>
+);
 
 export default Grid;

--- a/components/atoms/Icon/index.js
+++ b/components/atoms/Icon/index.js
@@ -1,7 +1,6 @@
 import React from "react";
 import Box from "components/atoms/Box";
 
-// Icons
 import ArrowRightUp from "./icons/ArrowRightUp.svg";
 import EyeSlash from "./icons/EyeSlash.svg";
 import ArrowDown from "./icons/ArrowDown.svg";
@@ -24,33 +23,38 @@ import Github from "./icons/Github.svg";
 import NewspaperClipping from "./icons/NewspaperClipping.svg";
 
 const iconTypes = {
-  ArrowRightUp: ArrowRightUp,
-  EyeSlash: EyeSlash,
-  ArrowDown: ArrowDown,
-  Chat: Chat,
-  Notebook: Notebook,
-  PieChart: PieChart,
-  StickyNote: StickyNote,
-  Copy: Copy,
-  ArrowsClockwise: ArrowsClockwise,
-  TreeStructure: TreeStructure,
-  Info: Info,
-  Moon: Moon,
-  Sun: Sun,
-  ArrowLeft: ArrowLeft,
-  Smiley: Smiley,
-  CircleWavyCheck: CircleWavyCheck,
-  FolderNotchOpen: FolderNotchOpen,
-  Code: Code,
-  Github: Github,
-  NewspaperClipping: NewspaperClipping,
+  ArrowRightUp,
+  EyeSlash,
+  ArrowDown,
+  Chat,
+  Notebook,
+  PieChart,
+  StickyNote,
+  Copy,
+  ArrowsClockwise,
+  TreeStructure,
+  Info,
+  Moon,
+  Sun,
+  ArrowLeft,
+  Smiley,
+  CircleWavyCheck,
+  FolderNotchOpen,
+  Code,
+  Github,
+  NewspaperClipping,
 };
 
-const Icon = ({ name, css, ...props }) => {
-  let _Icon = iconTypes[name];
+const Icon = ({ name, css, className = "", ...props }) => {
+  const SvgIcon = iconTypes[name];
+
+  if (!SvgIcon) {
+    return null;
+  }
+
   return (
-    <Box css={css}>
-      <_Icon {...props} style={{ height: "100%", width: "100%" }} />
+    <Box css={css} className={className}>
+      <SvgIcon {...props} style={{ height: "100%", width: "100%" }} />
     </Box>
   );
 };

--- a/components/atoms/Section.js
+++ b/components/atoms/Section.js
@@ -1,11 +1,9 @@
-import { styled } from "stitches.config";
+import { stitchesToStyle } from "lib/style";
 
-const Section = styled("section", {
-  padding: "$space500 0",
-
-  "@medium": {
-    padding: "$space800 0",
-  },
-});
+const Section = ({ className = "", css, style, children, ...props }) => (
+  <section className={`py-8 md:py-16 ${className}`.trim()} style={{ ...stitchesToStyle(css), ...style }} {...props}>
+    {children}
+  </section>
+);
 
 export default Section;

--- a/components/atoms/Text.js
+++ b/components/atoms/Text.js
@@ -1,123 +1,27 @@
-import { styled } from "stitches.config";
+import { stitchesToStyle } from "lib/style";
 
-const Text = styled("span", {
-  // Reset
-  display: "inline-block",
-  margin: 0,
-  color: "$gray000",
-  lineHeight: "calc(1em + 4px)",
-  position: "relative",
+const presetClasses = {
+  xLargeHeading:
+    "font-normal text-[28px] leading-8 pt-3 pb-4 md:text-[40px] md:leading-[48px] lg:text-[52px] lg:leading-[60px] lg:pt-4 lg:pb-8",
+  largeHeading:
+    "font-normal text-2xl leading-7 pt-1 pb-1 lg:text-4xl lg:leading-[44px] lg:pt-2",
+  heading: "font-normal text-xl leading-6 py-2 lg:text-[22px] lg:leading-7",
+  subHeading:
+    "font-normal text-lg leading-6 tracking-[0.01em] pt-1 pb-2 lg:text-xl lg:leading-7",
+  body: "font-normal text-base leading-6 tracking-[0.015em] lg:text-lg",
+  bodySmall: "font-normal text-sm leading-5",
+  overline:
+    "font-normal text-xs uppercase font-suisse-mono tracking-[0.075em] pb-1 lg:text-sm lg:pb-2",
+};
 
-  // Font Sizes
-  $$0: "14px",
-  $$1: "18px",
-  $$2: "20px",
-  $$3: "20px",
-  $$4: "32px",
-
-  "@large": {
-    $$0: "14px",
-    $$1: "18px",
-    $$2: "20px",
-    $$3: "28px",
-    $$4: "36px",
-  },
-
-  variants: {
-    preset: {
-      xLargeHeading: {
-        fontWeight: 400,
-        fontSize: "28px",
-        lineHeight: "32px",
-        paddingBottom: "$space300",
-        paddingTop: "$space200",
-
-        "@medium": {
-          fontSize: "40px",
-          lineHeight: "48px",
-        },
-
-        "@large": {
-          fontSize: "52px",
-          lineHeight: "60px",
-          paddingBottom: "$space500",
-          paddingTop: "$space300",
-        },
-      },
-      largeHeading: {
-        fontWeight: 400,
-        fontSize: "24px",
-        lineHeight: "28px",
-        paddingBottom: "$space000",
-        paddingTop: "$space000",
-
-        "@large": {
-          fontSize: "36px",
-          lineHeight: "44px",
-          paddingTop: "$space100",
-        },
-      },
-      heading: {
-        fontWeight: 400,
-        fontSize: "20px",
-        lineHeight: "24px",
-        paddingTop: "$space100",
-        paddingBottom: "$space100",
-
-        "@large": {
-          fontSize: "22px",
-          lineHeight: "28px",
-        },
-      },
-      subHeading: {
-        fontWeight: 400,
-        fontSize: "18px",
-        lineHeight: "24px",
-        letterSpacing: "0.01em",
-        paddingBottom: "$space100",
-        paddingTop: "$space000",
-
-        "@large": {
-          fontSize: "20px",
-          lineHeight: "28px",
-          paddingBottom: "$space100",
-        },
-      },
-      body: {
-        fontWeight: 400,
-        fontSize: "16px",
-        lineHeight: "24px",
-        letterSpacing: "0.015em",
-        "@large": {
-          fontSize: "18px",
-          lineHeight: "24px",
-          letterSpacing: "0.015em",
-        },
-      },
-      bodySmall: {
-        fontWeight: 400,
-        fontSize: "$$0",
-        lineHeight: "20px",
-      },
-      overline: {
-        fontWeight: 400,
-        fontSize: "12px",
-        textTransform: "uppercase",
-        fontFamily: "$suisseMono",
-        letterSpacing: "0.075em",
-        paddingBottom: "$space000",
-
-        "@large": {
-          fontSize: "14px",
-          paddingBottom: "$space100",
-        },
-      },
-    },
-  },
-
-  defaultVariants: {
-    preset: "body",
-  },
-});
+const Text = ({ as: Component = "span", preset = "body", css, style, className = "", children, ...props }) => (
+  <Component
+    className={`inline-block m-0 text-gray-0 leading-[calc(1em+4px)] relative ${presetClasses[preset] ?? presetClasses.body} ${className}`.trim()}
+    style={{ ...stitchesToStyle(css), ...style }}
+    {...props}
+  >
+    {children}
+  </Component>
+);
 
 export default Text;

--- a/components/molecules/AssetCard.js
+++ b/components/molecules/AssetCard.js
@@ -4,7 +4,6 @@ import Text from "components/atoms/Text";
 import Card from "components/atoms/Card";
 import Icon from "components/atoms/Icon";
 import { useState } from "react";
-import { AnimatePresence, AnimateSharedLayout } from "framer-motion";
 import Image from "next/image";
 
 const Caption = ({ open, text }) => {
@@ -52,7 +51,7 @@ const Caption = ({ open, text }) => {
   };
 
   return (
-    <AnimateSharedLayout>
+    <>
       <Box
         layout
         variants={parentVariants}
@@ -97,7 +96,7 @@ const Caption = ({ open, text }) => {
           </Box>
         )}
       </Box>
-    </AnimateSharedLayout>
+    </>
   );
 };
 
@@ -117,7 +116,15 @@ const AssetCard = ({ columns = 2, children, caption, image, imageAlt }) => {
     >
       <Card pressable={false}>
         <Flex align="center" justify="center">
-          {image && <Image src={image} alt={imageAlt} placeholder="blur" />}
+          {image && (
+            <Image
+              src={image}
+              alt={imageAlt || "Project asset"}
+              width={1440}
+              height={960}
+              style={{ width: "100%", height: "auto", display: "block" }}
+            />
+          )}
           {children}
         </Flex>
       </Card>

--- a/components/molecules/Carousel.js
+++ b/components/molecules/Carousel.js
@@ -1,75 +1,12 @@
-import { styled } from "stitches.config";
 import Box from "components/atoms/Box";
-import {
-  contentStyles,
-  contentWidth,
-  contentGutter,
-} from "components/atoms/Content";
-import Flex from "components/atoms/Flex";
 import Grid from "components/atoms/Grid";
 
-const Container = styled(Box, {
-  margin: "0 auto",
-
-  "@lessThanMedium": {
-    overflowX: "scroll",
-    paddingBottom: "$space300",
-  },
-
-  // Hide scrollbar
-  "::-webkit-scrollbar": {
-    display: "none" /* Chrome Safari */,
-    "-webkit-appearance": "none",
-    appearance: "none",
-    width: 0,
-    height: 0,
-  },
-  "scrollbar-width": "none" /* Firefox */,
-  "-ms-overflow-style": "none" /* IE 10+ */,
-});
-
-const Track = styled(Grid, {
-  // height: "100%",
-  // gap: "24px", // TODO: write polyfill
-  // justifyContent: "flex-start",
-  // display: "flex",
-  // flexDirection: "column",
-  // margin: "0 auto",
-  // width: "max-contsent",
-  // padding: "0 calc(((100vw - 1128px) / 2) - 20px)",
-  // margin: "0 20px",
-  // flexDirection: "row",
-
-  // "& > *": {
-  //   maxWidth: "calc(100vw - 80px)",
-  // },
-
-  defaultVariants: {
-    columns: 2,
-    gapSize: "default",
-  },
-
-  "@lessThanMedium": {
-    display: "flex",
-    width: "max-content",
-    padding: `0 ${contentGutter}`,
-    gapHorizontal: "8px",
-    "& > *": {
-      width: "calc(100vw - 80px)",
-      maxWidth: "500px",
-      maxHeight: "500px",
-    },
-  },
-
-  "@medium": {
-    ...contentStyles,
-  },
-});
-
-const Carousel = ({ children, mobileCarousel = false }) => (
-  <Container>
-    <Track carousel={mobileCarousel}>{children}</Track>
-  </Container>
+const Carousel = ({ children }) => (
+  <Box className="mx-auto max-md:overflow-x-scroll max-md:pb-4 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+    <Grid className="md:mx-auto md:w-[calc(100%-32px)] md:max-w-[1128px] lg:w-[calc(100%-80px)] max-md:flex max-md:w-max max-md:px-4 max-md:gap-2 max-md:[&>*]:w-[calc(100vw-80px)] max-md:[&>*]:max-w-[500px] max-md:[&>*]:max-h-[500px]" columns={2}>
+      {children}
+    </Grid>
+  </Box>
 );
 
 export default Carousel;

--- a/components/molecules/Landing.js
+++ b/components/molecules/Landing.js
@@ -1,12 +1,9 @@
-import { styled } from "../../stitches.config";
 import Section from "components/atoms/Section";
 
-const Landing = styled(Section, {
-  paddingBottom: 0,
-  paddingTop: "$space700",
-  "@large": {
-    paddingTop: "$space800",
-  },
-});
+const Landing = ({ children, className = "", ...props }) => (
+  <Section className={`pt-16 lg:pt-24 pb-0 ${className}`.trim()} {...props}>
+    {children}
+  </Section>
+);
 
 export default Landing;

--- a/components/molecules/ProjectCard.js
+++ b/components/molecules/ProjectCard.js
@@ -58,7 +58,7 @@ const ProjectCard = ({
             alt={imageAlt}
             layout="fill"
             objectFit="cover"
-            placeholder="blur"
+           
           />
         </Box>
       )}

--- a/components/organisms/Menu.js
+++ b/components/organisms/Menu.js
@@ -1,139 +1,38 @@
 import Box from "components/atoms/Box";
 import Flex from "components/atoms/Flex";
 import Text from "components/atoms/Text";
-import Content from "components/atoms/Content";
 import LinkTo from "components/utilities/LinkTo";
 import { useRouter } from "next/router";
-import { styled } from "stitches.config";
-import { AnimatePresence, AnimateSharedLayout } from "framer-motion";
-import Image from "next/image";
-import React, { useEffect, useState } from "react";
-import Icon from "components/atoms/Icon";
-import { useTheme } from "next-themes";
+import React from "react";
 
-const _Menu = styled(Flex, {
-  backgroundColor: "$gray800",
-  padding: "$space200",
-  borderRadius: "999px",
-  flexDirection: "row",
-  overflow: "hidden",
-  display: "inline-flex",
-  gapHorizontal: "$space200",
-  flex: "initial",
-  pointerEvents: "all",
-  align: "center",
-  color: "$gray200",
-  width: "max-content",
-  boxShadow:
-    "0px 4px 4px 0px rgba(0, 0, 0, 0.7), 0px 0px 24px 0px rgba(0, 0, 0, 0.5)",
-});
-
-const Item = styled(Box, {
-  transition: "$default",
-  padding: "$space100 $space300",
-  position: "relative",
-  borderRadius: "999px",
-  display: "inline-flex",
-  width: "max-content",
-
-  variants: {
-    active: {
-      true: {
-        color: "$gray1000",
-        "&:hover": {
-          color: "$gray1000",
-        },
-      },
-      false: {
-        color: "$gray200",
-        "&:hover": {
-          backgroundColor: "$gray600",
-          color: "$gray000",
-        },
-      },
-    },
-  },
-
-  defaultVariants: {
-    active: false,
-  },
-});
-
-const Highlight = styled(Box, {
-  position: "absolute",
-  top: 0,
-  bottom: 0,
-  left: 0,
-  right: 0,
-  backgroundColor: "$gray000",
-  borderRadius: "999px",
-  zIndex: 0,
-  display: "block",
-});
-
-const MenuItem = ({ href = "", path, label, children, icon, layoutId }) => {
+const MenuItem = ({ href = "", path, label }) => {
   const active = path === href;
 
   return (
     <LinkTo href={href}>
-      <Item
-        active={active}
-        key={label}
+      <Box
+        className={`transition-all px-4 py-2 relative rounded-full inline-flex w-max ${
+          active ? "text-gray-1000" : "text-gray-200 hover:bg-gray-600 hover:text-gray-0"
+        }`}
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}
       >
-        <Text preset="body" css={{ color: "inherit", zIndex: 10 }} key="text">
+        <Text preset="body" className="text-inherit z-10">
           {label}
         </Text>
         {active && (
-          <Highlight
+          <Box
             layout
             layoutId="highlight"
-            key="highlight"
+            className="absolute inset-0 bg-gray-0 rounded-full z-0 block"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
           />
         )}
-      </Item>
+      </Box>
     </LinkTo>
-  );
-};
-
-const ThemeToggle = () => {
-  const [mounted, setMounted] = useState(false);
-  const { setTheme, resolvedTheme } = useTheme();
-
-  useEffect(() => setMounted(true), []);
-
-  if (!mounted) return null;
-
-  const toggleTheme = () => {
-    const targetTheme = resolvedTheme === "light" ? "dark" : "light";
-
-    setTheme(targetTheme);
-  };
-  return (
-    <Flex
-      align="center"
-      onClick={toggleTheme}
-      css={{
-        padding: "12px",
-        borderRadius: "9999px",
-        border: "1px $gray700 solid",
-        cursor: "pointer",
-        overflow: "hidden",
-        boxSizing: "border-box",
-      }}
-    >
-      {resolvedTheme === "dark" && (
-        <Icon name="Moon" css={{ width: "16px", height: "16px" }} />
-      )}
-      {resolvedTheme === "light" && (
-        <Icon name="Sun" css={{ width: "16px", height: "16px" }} />
-      )}
-    </Flex>
   );
 };
 
@@ -141,22 +40,14 @@ const Menu = () => {
   const router = useRouter();
   const path = router.pathname;
 
-  const isProject = path.includes("project");
-
   return (
-    <_Menu layout>
-      <AnimateSharedLayout>
-        <MenuItem
-          href="/"
-          path={path}
-          label="Work"
-          layoutId="work"
-          icon={isProject}
-        />
-        <MenuItem href="/about" path={path} label="About Me" layoutId="about" />
-        {/* <ThemeToggle /> */}
-      </AnimateSharedLayout>
-    </_Menu>
+    <Flex
+      layout
+      className="bg-gray-800 p-3 rounded-[999px] overflow-hidden inline-flex flex-row gap-3 !flex-none pointer-events-auto items-center text-gray-200 w-max shadow-[0_4px_4px_0_rgba(0,0,0,0.7),0_0_24px_0_rgba(0,0,0,0.5)]"
+    >
+      <MenuItem href="/" path={path} label="Work" />
+      <MenuItem href="/about" path={path} label="About Me" />
+    </Flex>
   );
 };
 

--- a/components/utilities/LinkTo.js
+++ b/components/utilities/LinkTo.js
@@ -1,9 +1,6 @@
 import Link from "next/link";
 import React from "react";
 
-/// A unified component for the next/link <Link> and a standard <a> anchor.
-/// Will lift href and all other props from NextLinkProps up to the Link.
-/// Will automatically make an <a> tag containing the children and pass it remaining props.
 const LinkTo = ({
   children,
   href,
@@ -15,29 +12,30 @@ const LinkTo = ({
   locale,
   displayContents = false,
   newTab = false,
+  style,
   ...anchorProps
-}) => {
-  return (
-    // These props are lifted up to the `Link` element. All others are passed to the `<a>`
-    <Link
-      {...{ href, as, replace, scroll, shallow, prefetch, locale }}
-      scroll={false}
-    >
-      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <a
-        style={{
-          color: "inherit",
-          textDecoration: "none",
-          display: displayContents ? "contents" : "block",
-          cursor: "pointer",
-        }}
-        target={newTab ? "_blank" : ""}
-        {...anchorProps}
-      >
-        {children}
-      </a>
-    </Link>
-  );
-};
+}) => (
+  <Link
+    href={href}
+    as={as}
+    replace={replace}
+    scroll={scroll ?? false}
+    shallow={shallow}
+    prefetch={prefetch}
+    locale={locale}
+    target={newTab ? "_blank" : undefined}
+    rel={newTab ? "noreferrer" : undefined}
+    style={{
+      color: "inherit",
+      textDecoration: "none",
+      display: displayContents ? "contents" : "block",
+      cursor: "pointer",
+      ...style,
+    }}
+    {...anchorProps}
+  >
+    {children}
+  </Link>
+);
 
 export default LinkTo;

--- a/lib/style.js
+++ b/lib/style.js
@@ -1,0 +1,50 @@
+const TOKEN_MAP = {
+  gray000: "var(--gray000)",
+  gray100: "var(--gray100)",
+  gray200: "var(--gray200)",
+  gray300: "var(--gray300)",
+  gray400: "var(--gray400)",
+  gray500: "var(--gray500)",
+  gray600: "var(--gray600)",
+  gray700: "var(--gray700)",
+  gray800: "var(--gray800)",
+  gray900: "var(--gray900)",
+  gray1000: "var(--gray1000)",
+  accent: "var(--accent)",
+  space000: "var(--space000)",
+  space100: "var(--space100)",
+  space200: "var(--space200)",
+  space300: "var(--space300)",
+  space400: "var(--space400)",
+  space500: "var(--space500)",
+  space600: "var(--space600)",
+  space700: "var(--space700)",
+  space800: "var(--space800)",
+  space900: "var(--space900)",
+};
+
+const replaceTokens = (value) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  return value
+    .replace(/\$colors\$([a-zA-Z0-9]+)/g, (_, token) => TOKEN_MAP[token] ?? `$${token}`)
+    .replace(/\$space\$([a-zA-Z0-9]+)/g, (_, token) => TOKEN_MAP[token] ?? `$${token}`)
+    .replace(/\$([a-zA-Z0-9]+)/g, (_, token) => TOKEN_MAP[token] ?? `$${token}`);
+};
+
+export const stitchesToStyle = (css = {}) => {
+  if (!css) {
+    return undefined;
+  }
+
+  return Object.entries(css).reduce((style, [key, value]) => {
+    if (key.startsWith("@") || key.startsWith("&")) {
+      return style;
+    }
+
+    style[key] = replaceTokens(value);
+    return style;
+  }, {});
+};

--- a/package.json
+++ b/package.json
@@ -8,26 +8,28 @@
     "start": "next start"
   },
   "dependencies": {
-    "@stitches/react": "^0.2.2",
-    "framer-motion": "^4.1.17",
-    "next": "11.0.0",
-    "next-seo": "^4.26.0",
-    "next-themes": "^0.0.14",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "framer-motion": "^11.18.2",
+    "next": "^15.1.0",
+    "next-seo": "^6.6.0",
+    "next-themes": "^0.4.4",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   },
   "devDependencies": {
-    "@svgr/webpack": "^5.5.0",
-    "babel-plugin-inline-react-svg": "^1.0.1",
-    "eslint": "^7.16.0",
-    "eslint-config-airbnb": "^18.1.0",
-    "eslint-config-next": "^11.0.0",
-    "eslint-config-prettier": "^7.2.0",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-prettier": "^3.3.1",
-    "eslint-plugin-react": "^7.19.0",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "prettier": "^2.2.1"
+    "@svgr/webpack": "^8.1.0",
+    "autoprefixer": "^10.4.20",
+    "babel-plugin-inline-react-svg": "^2.0.2",
+    "eslint": "^9.20.1",
+    "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-next": "^15.1.0",
+    "eslint-config-prettier": "^10.0.1",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-jsx-a11y": "^6.10.2",
+    "eslint-plugin-prettier": "^5.2.3",
+    "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.1.0",
+    "postcss": "^8.5.2",
+    "prettier": "^3.5.1",
+    "tailwindcss": "^3.4.17"
   }
 }

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,12 +1,8 @@
-import { globalStyles, lightTheme } from "stitches.config";
-import { motion, AnimatePresence, AnimateSharedLayout } from "framer-motion";
-import Menu from "components/organisms/Menu";
+import "styles/globals.css";
+import { AnimatePresence } from "framer-motion";
 import Box from "components/atoms/Box";
-import { useEffect, useRef, useState } from "react";
+import { useEffect } from "react";
 import { ThemeProvider } from "next-themes";
-import Content from "components/atoms/Content";
-import Flex from "components/atoms/Flex";
-import Image from "next/image";
 import Header from "components/molecules/Header";
 import { Footer } from "components/molecules/Footer";
 import { DefaultSeo } from "next-seo";
@@ -16,8 +12,6 @@ import * as gtag from "../lib/gtag";
 import SEO from "../next-seo.config";
 
 function MyApp({ Component, pageProps }) {
-  globalStyles();
-
   useEffect(() => {
     window.history.scrollRestoration = "manual";
   }, []);
@@ -50,31 +44,17 @@ function MyApp({ Component, pageProps }) {
   };
 
   return (
-    <ThemeProvider
-      attribute="class"
-      defaultTheme="dark"
-      value={{
-        dark: "dark",
-        // light: lightTheme.className,
-      }}
-    >
-      <Box
-        css={{
-          perspective: "1000px",
-          "perspective-origin": "center center",
-        }}
-      >
-        <AnimatePresence exitBeforeEnter onExitComplete={handleExitComplete}>
+    <ThemeProvider attribute="class" defaultTheme="dark" value={{ dark: "dark" }}>
+      <Box className="[perspective:1000px] [perspective-origin:center_center]">
+        <AnimatePresence mode="wait" onExitComplete={handleExitComplete}>
           <Box
             key={router.pathname}
             transition={spring}
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            originZ={0}
           >
             <DefaultSeo {...SEO} />
-            {/* Global Site Tag (gtag.js) - Google Analytics */}
             <Script
               strategy="afterInteractive"
               src={`https://www.googletagmanager.com/gtag/js?id=${gtag.GA_TRACKING_ID}`}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,28 +1,7 @@
 import React from "react";
 import NextDocument, { Html, Head, Main, NextScript } from "next/document";
-import { getCssString, lightTheme } from "../stitches.config";
 
 export default class Document extends NextDocument {
-  static async getInitialProps(ctx) {
-    try {
-      const initialProps = await NextDocument.getInitialProps(ctx);
-
-      return {
-        ...initialProps,
-        styles: (
-          <>
-            {initialProps.styles}
-            <style
-              id="stitches"
-              dangerouslySetInnerHTML={{ __html: getCssString() }}
-            />
-          </>
-        ),
-      };
-    } finally {
-    }
-  }
-
   render() {
     return (
       <Html lang="en">
@@ -43,29 +22,14 @@ export default class Document extends NextDocument {
             crossOrigin="anonymous"
           />
 
-          {/* Generics */}
           <link rel="icon" href="/favicons/favicon-16x16.png" sizes="16x16" />
           <link rel="icon" href="/favicons/favicon-32x32.png" sizes="32x32" />
           <link rel="icon" href="/favicons/favicon-96x96.png" sizes="96x96" />
-          <link
-            rel="icon"
-            href="/favicons/favicon-128x128.png"
-            sizes="128x128"
-          />
-          <link
-            rel="icon"
-            href="/favicons/favicon-196x196.png"
-            sizes="192x192"
-          />
+          <link rel="icon" href="/favicons/favicon-128x128.png" sizes="128x128" />
+          <link rel="icon" href="/favicons/favicon-196x196.png" sizes="192x192" />
 
-          {/* Android */}
-          <link
-            rel="shortcut icon"
-            sizes="196x196"
-            href="/favicons/favicon-196x196.png"
-          />
+          <link rel="shortcut icon" sizes="196x196" href="/favicons/favicon-196x196.png" />
 
-          {/* iOS */}
           <link
             rel="apple-touch-icon"
             href="/favicons/apple-touch-icon-120x120.png"
@@ -82,12 +46,8 @@ export default class Document extends NextDocument {
             sizes="180x180"
           />
 
-          {/* Windows */}
           <meta name="msapplication-TileColor" content="#FFFFFF" />
-          <meta
-            name="msapplication-TileImage"
-            content="/favicons/mstile-144x144.png"
-          />
+          <meta name="msapplication-TileImage" content="/favicons/mstile-144x144.png" />
         </Head>
         <body>
           <Main />

--- a/pages/about.js
+++ b/pages/about.js
@@ -1,4 +1,3 @@
-import Card from "components/atoms/Card";
 import Content from "components/atoms/Content";
 import Section from "components/atoms/Section";
 import Text from "components/atoms/Text";
@@ -7,19 +6,14 @@ import Page from "components/templates/Page";
 import Image from "next/image";
 import Box from "components/atoms/Box";
 import LinkTo from "components/utilities/LinkTo";
-import { styled } from "stitches.config";
 import Landing from "components/molecules/Landing";
 import Grid from "components/atoms/Grid";
 import AssetCard from "components/molecules/AssetCard";
 import CopyToClipboardButton from "components/molecules/CopyToClipboardButton";
 
-const LinkText = styled("span", {
-  color: "$accent",
-});
-
 const Link = ({ href, children }) => (
   <LinkTo href={href} displayContents>
-    <LinkText>{children}</LinkText>
+    <span className="text-accent">{children}</span>
   </LinkTo>
 );
 
@@ -31,15 +25,9 @@ export default function About() {
     >
       <Landing>
         <Content>
-          <Box css={{ marginBottom: "$space500" }}>
-            <Text
-              preset="xLargeHeading"
-              css={{ maxWidth: "30ch", width: "100%" }}
-            >
-              Aaron Porter is a designer & technologist. Previously at{" "}
-              <Link href="https://getcarefull.com">Carefull</Link>,{" "}
-              <Link href="https://truetoform.design">TTF</Link>, &{" "}
-              <Link href="https://google.com">Google</Link>.
+          <Box className="mb-8">
+            <Text preset="xLargeHeading" className="max-w-[30ch] w-full">
+              Aaron Porter is a designer & technologist. Previously at <Link href="https://getcarefull.com">Carefull</Link>, <Link href="https://truetoform.design">TTF</Link>, & <Link href="https://google.com">Google</Link>.
               <br />
               Now independent.
               <br />
@@ -48,106 +36,53 @@ export default function About() {
           <Box>
             <Text preset="subHeading">A bit about me</Text>
             <Grid columns={2} gapSize="large">
-              <Text css={{ color: "$gray300" }}>
-                I started designing at 13. Living in a rural area with a limited
-                internet connection, I lugged our family’s iMac to a friend’s
-                house to download a (totally legal) copy of adobe illustrator.{" "}
+              <Text className="text-gray-300">
+                I started designing at 13. Living in a rural area with a limited internet connection, I lugged our family’s iMac to a friend’s house to download a (totally legal) copy of adobe illustrator. <br />
                 <br />
-                <br />
-                I’ve approached my career since then with a similar amount of
-                vigour. Always seeking to learn, understand, and evolve. I find
-                joy in the process of piecing together small parts of the built
-                world. Guided by the hope that my work can help to create
-                products that are subservient to the individual, systems that
-                empower human agency, and experiences that foster understanding.
+                I’ve approached my career since then with a similar amount of vigour. Always seeking to learn, understand, and evolve. I find joy in the process of piecing together small parts of the built world. Guided by the hope that my work can help to create products that are subservient to the individual, systems that empower human agency, and experiences that foster understanding.
               </Text>
-              <Text css={{ color: "$gray300" }}>
-                When I’m not designing, you can find me obsessively reading,
-                spreadsheeting, or annoying my wife about my obsession of the
-                month. Past episodes have included: optimization of
-                tax-advantage investment accounts, the perfect t-shirt,
-                correcting my broken body due to 10+ years of sitting at a
-                computer, & much more. Feel free to ask and I’ll fill you into
-                the featured selection. <br />
+              <Text className="text-gray-300">
+                When I’m not designing, you can find me obsessively reading, spreadsheeting, or annoying my wife about my obsession of the month. Past episodes have included: optimization of tax-advantage investment accounts, the perfect t-shirt, correcting my broken body due to 10+ years of sitting at a computer, & much more. Feel free to ask and I’ll fill you into the featured selection. <br />
                 <br />
-                I’m currently based in Grand Rapids, Michigan. The city I went
-                to college, met my wife, and a place that seems to consistently
-                pull me back.
+                I’m currently based in Grand Rapids, Michigan. The city I went to college, met my wife, and a place that seems to consistently pull me back.
               </Text>
             </Grid>
           </Box>
           <Section>
-            <Text
-              preset="overline"
-              css={{ color: "$gray300", paddingBottom: "$space400" }}
-            >
+            <Text preset="overline" className="text-gray-300 pb-6">
               A bunch of photos of me, you’re welcome
             </Text>
             <Flex gap align="start">
               <Flex direction="column" gap>
                 <AssetCard caption="This what I look like roughly. Less serious most of the time.">
-                  <Image
-                    src="/images/aaronporter_about_1@2x.jpg"
-                    alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-                    width={1104}
-                    height={1544}
-                  />
+                  <Image src="/images/aaronporter_about_1@2x.jpg" alt="Portrait" width={1104} height={1544} />
                 </AssetCard>
                 <AssetCard caption="Always looking to capture an authentic moment.">
-                  <Image
-                    src="/images/aaronporter_about_3@2x.jpg"
-                    alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-                    width={1104}
-                    height={1508}
-                  />
+                  <Image src="/images/aaronporter_about_3@2x.jpg" alt="Portrait" width={1104} height={1508} />
                 </AssetCard>
                 <AssetCard caption="I go outside sometimes!">
-                  <Image
-                    src="/images/aaronporter_about_5@2x.jpg"
-                    alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-                    width={1104}
-                    height={1508}
-                  />
+                  <Image src="/images/aaronporter_about_5@2x.jpg" alt="Portrait" width={1104} height={1508} />
                 </AssetCard>
               </Flex>
               <Flex direction="column" gap>
                 <AssetCard caption="Fitting in a bit of work in Acadia National Park. I'm really great at work life balance!">
-                  <Image
-                    src="/images/aaronporter_about_2@2x.jpg"
-                    alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-                    width={1104}
-                    height={1396}
-                  />
+                  <Image src="/images/aaronporter_about_2@2x.jpg" alt="Portrait" width={1104} height={1396} />
                 </AssetCard>
                 <AssetCard caption="Married up.">
-                  <Image
-                    src="/images/aaronporter_about_4@2x.jpg"
-                    alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-                    width={1104}
-                    height={1526}
-                  />
+                  <Image src="/images/aaronporter_about_4@2x.jpg" alt="Portrait" width={1104} height={1526} />
                 </AssetCard>
 
                 <AssetCard caption="Always wear your protect gear.">
-                  <Image
-                    src="/images/aaronporter_about_6@2x.jpg"
-                    alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-                    width={1104}
-                    height={1352}
-                  />
+                  <Image src="/images/aaronporter_about_6@2x.jpg" alt="Portrait" width={1104} height={1352} />
                 </AssetCard>
               </Flex>
             </Flex>
           </Section>
           <Section>
-            <Box css={{ margin: "0 auto", textAlign: "center" }}>
-              <Text preset="largeHeading">
-                That's all. Hire me or something.
-              </Text>
-              <Box css={{ marginTop: "$space400" }}>
-                <CopyToClipboardButton value="hello@aaronporter.co">
-                  hello@aaronporter.co
-                </CopyToClipboardButton>
+            <Box className="mx-auto text-center">
+              <Text preset="largeHeading">That's all. Hire me or something.</Text>
+              <Box className="mt-6">
+                <CopyToClipboardButton value="hello@aaronporter.co">hello@aaronporter.co</CopyToClipboardButton>
               </Box>
             </Box>
           </Section>

--- a/pages/index.js
+++ b/pages/index.js
@@ -12,12 +12,12 @@ import Page from "components/templates/Page";
 import Grid from "components/atoms/Grid";
 import Landing from "components/molecules/Landing";
 
-import image1 from "../public/projects/carefull/carefull_image_1@2x.png";
-import image2 from "../public/projects/stories/stories_thumbnail@2x.png";
-import image3 from "../public/projects/2016-portfolio/portfolio_thumbnail.jpg";
-import image4 from "../public/projects/2001-space/2001_thumbnail.png";
-import image5 from "../public/projects/beach/beach_thumbnail.jpg";
-import image6 from "../public/projects/brandsupplies/BrandSupplies@2x.png";
+const image1 = "/projects/carefull/carefull_image_1@2x.png";
+const image2 = "/projects/stories/stories_thumbnail@2x.png";
+const image3 = "/projects/2016-portfolio/portfolio_thumbnail.jpg";
+const image4 = "/projects/2001-space/2001_thumbnail.png";
+const image5 = "/projects/beach/beach_thumbnail.jpg";
+const image6 = "/projects/brandsupplies/BrandSupplies@2x.png";
 
 export default function Home() {
   return (
@@ -50,9 +50,9 @@ export default function Home() {
                 <Image
                   src={image1}
                   alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-                  layout="responsive"
+                  width={552}
+                  height={552}
                   priority
-                  placeholder="blur"
                 />
               }
             />

--- a/pages/projects/carefull.js
+++ b/pages/projects/carefull.js
@@ -11,17 +11,17 @@ import TextCard from "components/molecules/TextCard";
 import PortfolioPresentationCard from "components/organisms/PortfolioPresentationCard";
 import List from "../../components/organisms/List";
 
-import image1 from "../../public/projects/carefull/carefull_image_1@2x.png";
-import image2 from "../../public/projects/carefull/Carefull_Logo@2x.png";
-import image3 from "../../public/projects/carefull/Carefull_Icon@2x.png";
-import image4 from "../../public/projects/carefull/Carefull_Collage@2x.png";
-import image5 from "../../public/projects/carefull/Carefull_Print_1@2x.png";
-import image6 from "../../public/projects/carefull/Carefull_Print_2@2x.png";
-import image7 from "../../public/projects/carefull/Carefull_UX_1@2x.png";
-import image8 from "../../public/projects/carefull/Carefull_UX_2@2x.png";
-import image9 from "../../public/projects/carefull/Carefull_UX_3@2x.png";
-import image10 from "../../public/projects/carefull/Carefull_UX_4@2x.png";
-import image11 from "../../public/projects/carefull/Carefull_UX_5@2x.png";
+const image1 = "/projects/carefull/carefull_image_1@2x.png";
+const image2 = "/projects/carefull/Carefull_Logo@2x.png";
+const image3 = "/projects/carefull/Carefull_Icon@2x.png";
+const image4 = "/projects/carefull/Carefull_Collage@2x.png";
+const image5 = "/projects/carefull/Carefull_Print_1@2x.png";
+const image6 = "/projects/carefull/Carefull_Print_2@2x.png";
+const image7 = "/projects/carefull/Carefull_UX_1@2x.png";
+const image8 = "/projects/carefull/Carefull_UX_2@2x.png";
+const image9 = "/projects/carefull/Carefull_UX_3@2x.png";
+const image10 = "/projects/carefull/Carefull_UX_4@2x.png";
+const image11 = "/projects/carefull/Carefull_UX_5@2x.png";
 
 export default function Carefull() {
   return (
@@ -40,7 +40,7 @@ export default function Carefull() {
           <Image
             src={image1}
             alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-            placeholder="blur"
+           
             width={552}
             height={552}
           />

--- a/pages/projects/wayfair.js
+++ b/pages/projects/wayfair.js
@@ -11,8 +11,8 @@ import TextCard from "components/molecules/TextCard";
 import PortfolioPresentationCard from "components/organisms/PortfolioPresentationCard";
 import List from "components/organisms/List";
 
-import image1 from "../../public/projects/wayfair/Wayfair_Image_1@2x.png";
-import image2 from "../../public/projects/wayfair/Wayfair_Image_2@2x.png";
+const image1 = "/projects/wayfair/Wayfair_Image_1@2x.png";
+const image2 = "/projects/wayfair/Wayfair_Image_2@2x.png";
 
 export default function Carefull() {
   return (
@@ -31,7 +31,9 @@ export default function Carefull() {
           <Image
             src={image1}
             alt="Picture of a mother and son embracing eachother. A purple ring surrounds them showing protection."
-            placeholder="blur"
+            width={1200}
+            height={800}
+            style={{ width: "100%", height: "auto", display: "block" }}
           />
         </Card>
       </ProjectIntro>

--- a/pages/projects/youtube.js
+++ b/pages/projects/youtube.js
@@ -11,11 +11,11 @@ import TextCard from "components/molecules/TextCard";
 import PortfolioPresentationCard from "components/organisms/PortfolioPresentationCard";
 import List from "components/organisms/List";
 
-import image1 from "../../public/projects/youtube/Youtube_Premium@2x.png";
-import image2 from "../../public/projects/youtube/Youtube_Japan_1.jpg";
-import image3 from "../../public/projects/youtube/Youtube_UI_1@2x.png";
-import image4 from "../../public/projects/youtube/Youtube_UI_2@2x.png";
-import image5 from "../../public/projects/youtube/Youtube_UI_3@2x.png";
+const image1 = "/projects/youtube/Youtube_Premium@2x.png";
+const image2 = "/projects/youtube/Youtube_Japan_1.jpg";
+const image3 = "/projects/youtube/Youtube_UI_1@2x.png";
+const image4 = "/projects/youtube/Youtube_UI_2@2x.png";
+const image5 = "/projects/youtube/Youtube_UI_3@2x.png";
 
 export default function Carefull() {
   return (
@@ -31,7 +31,13 @@ export default function Carefull() {
       >
         <ConfidentialBanner css={{ marginBottom: "$space400" }} />
         <Card pressable={false} align="center" justify="center">
-          <Image src={image1} alt="YouTube Premium logo" placeholder="blur" />
+          <Image
+            src={image1}
+            alt="YouTube Premium logo"
+            width={1200}
+            height={800}
+            style={{ width: "100%", height: "auto", display: "block" }}
+          />
         </Card>
       </ProjectIntro>
       <ProjectHighlight label="About The Project">

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,54 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --gray000: #ffffff;
+  --gray100: #e9e9e9;
+  --gray200: #d9d9d9;
+  --gray300: #c4c4c4;
+  --gray400: #9d9d9d;
+  --gray500: #7b7b7b;
+  --gray600: #555555;
+  --gray700: #434343;
+  --gray800: #262626;
+  --gray900: #101010;
+  --gray1000: #000000;
+  --accent: #f66141;
+  --space000: 4px;
+  --space100: 8px;
+  --space200: 12px;
+  --space300: 16px;
+  --space400: 24px;
+  --space500: 32px;
+  --space600: 40px;
+  --space700: 64px;
+  --space800: 128px;
+  --space900: 192px;
+}
+
+.light {
+  --gray000: #000000;
+  --gray100: #101010;
+  --gray200: #262626;
+  --gray300: #434343;
+  --gray400: #555555;
+  --gray500: #7b7b7b;
+  --gray600: #9d9d9d;
+  --gray700: #c4c4c4;
+  --gray800: #d9d9d9;
+  --gray900: #e9e9e9;
+  --gray1000: #ffffff;
+}
+
+html {
+  font-family: "Suisse", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  overflow: auto;
+  margin: 0;
+  background: var(--gray1000);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,30 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  darkMode: "class",
+  content: ["./pages/**/*.{js,jsx}", "./components/**/*.{js,jsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        suisse: ["Suisse", "system-ui", "sans-serif"],
+        "suisse-mono": ["Suisse Mono", "monospace"],
+      },
+      colors: {
+        gray: {
+          0: "var(--gray000)",
+          100: "var(--gray100)",
+          200: "var(--gray200)",
+          300: "var(--gray300)",
+          400: "var(--gray400)",
+          500: "var(--gray500)",
+          600: "var(--gray600)",
+          700: "var(--gray700)",
+          800: "var(--gray800)",
+          900: "var(--gray900)",
+          1000: "var(--gray1000)",
+        },
+        accent: "var(--accent)",
+      },
+    },
+  },
+  plugins: [],
+};


### PR DESCRIPTION
### Motivation
- Remove custom environment and Stitches-specific runtime hacks and follow standard Next.js/Tailwind conventions for clearer, maintainable scaffolding. 
- Migrate components away from Stitches styling toward Tailwind utility classes while preserving a small adapter to translate legacy `css` tokens. 
- Modernize image usage to Next.js best practices (`next/image`) and make component APIs simpler and framework-friendly. 

### Description
- Added a small adapter `lib/style.js` exporting `stitchesToStyle` to map legacy design tokens to CSS variables and allow existing `css` props to work with inline `style`. 
- Rewrote core atoms (`Box`, `Flex`, `Grid`, `Text`, `Card`, `Button`, `Section`, `Content`) to plain React components that use Tailwind classes and accept `className`/`css`/`style` instead of Stitches `styled` usage. 
- Updated molecules/organisms and pages to use `next/image` with explicit dimensions, simplified `LinkTo`, simplified `Menu` structure, and converted carousel/landing/layout pieces to Tailwind-friendly markup. 
- Added standard Tailwind/PostCSS setup files (`tailwind.config.js`, `postcss.config.js`, `styles/globals.css`) and updated `package.json` dependency targets to modern Next/React/dev tools expected by this setup. 

### Testing
- Ran `npm install` which failed due to registry/network policy returning `403 Forbidden`, so dependencies could not be installed. 
- Ran `npm run build` which failed because `tailwindcss` is not present in `node_modules` (direct consequence of the blocked `npm install`). 
- Ran `npm run dev` which also failed for the same missing dependency reason, so the app could not be started in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69927e9db7848330a34edf3af3803ce2)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large UI refactor plus major framework upgrades (Next 11→15, React 17→19, framer-motion 4→11) can introduce runtime/styling regressions and `next/image` behavior changes across pages.
> 
> **Overview**
> Migrates the UI styling approach from Stitches `styled` components to plain React components using Tailwind utility classes, keeping limited backward compatibility via a new `stitchesToStyle` adapter that maps legacy `css` token values to CSS variables.
> 
> Adds Tailwind/PostCSS scaffolding (`tailwind.config.js`, `postcss.config.js`, `styles/globals.css`) and switches app bootstrapping to standard global CSS import, removing Stitches SSR injection from `_document` and `globalStyles()` usage.
> 
> Modernizes core dependencies and component usage: upgrades Next/React/framer-motion/eslint toolchain, simplifies `LinkTo` to rely on Next’s Link props (including `target`/`rel` for new tabs), updates menu/carousel/landing layouts accordingly, and adjusts multiple `next/image` usages to explicit `width`/`height` and string asset paths while removing `placeholder="blur"` usage in several places.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85cd3a469a027654e37b60134965a48ef423f33d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->